### PR TITLE
Handle non initialized ad size

### DIFF
--- a/src/ads/src/main/java/com/poingstudios/godot/admob/ads/adformats/Banner.kt
+++ b/src/ads/src/main/java/com/poingstudios/godot/admob/ads/adformats/Banner.kt
@@ -236,19 +236,31 @@ class Banner(
     }
 
     fun getWidth() : Int {
-        return mAdSize.width
+        if (this::mAdSize.isInitialized) {
+            return mAdSize.width
+        }
+        return 0
     }
 
     fun getHeight() : Int{
-        return mAdSize.height
+        if (this::mAdSize.isInitialized) {
+            return mAdSize.height
+        }
+        return 0
     }
 
     fun getWidthInPixels() : Int{
-        return mAdSize.getWidthInPixels(activity)
+        if (this::mAdSize.isInitialized) {
+            return mAdSize.getWidthInPixels(activity);
+        }
+        return 0
     }
 
     fun getHeightInPixels() : Int {
-        return mAdSize.getHeightInPixels(activity)
+        if (this::mAdSize.isInitialized) {
+            return mAdSize.getHeightInPixels(activity)
+        }
+        return 0
     }
 
 }

--- a/src/core/src/main/java/com/poingstudios/godot/admob/core/utils/PluginConfiguration.kt
+++ b/src/core/src/main/java/com/poingstudios/godot/admob/core/utils/PluginConfiguration.kt
@@ -2,6 +2,6 @@ package com.poingstudios.godot.admob.core.utils
 
 class PluginConfiguration {
     object Constants {
-        const val PLUGIN_VERSION = "3.0.4"
+        const val PLUGIN_VERSION = "3.0.5"
     }
 }


### PR DESCRIPTION
This PR solves the issue reported on [Issue 230](https://github.com/poingstudios/godot-admob-android/issues/230)

When the adsize for the banner is requested, it checks if it has been initialized, otherwise it leads to a crash.

