### PR TITLE
Fix top banner ad position is leaving a wide gap

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Issue with AdMob on iOS only
-    url: https://github.com/Poing-Studios/godot-admob-ios
+    url: https://github.com/poingstudios/godot-admob-ios
     about: Check the iOS plugin repository.
   - name: Issue with AdMob on Godot Editor
-    url: https://github.com/Poing-Studios/godot-admob-plugin
+    url: https://github.com/poingstudios/godot-admob-plugin
     about: Check the Godot plugin repository.

--- a/README.md
+++ b/README.md
@@ -10,24 +10,24 @@
 <h4 align="center">A Godot's plugin for Android of <a href="https://admob.google.com" target="_blank">AdMob</a>.</h4>
 
 <p align="center">
-  <a href="https://github.com/Poing-Studios/godot-admob-android/releases">
-    <img src="https://img.shields.io/github/v/tag/Poing-Studios/godot-admob-android?label=Version">
+  <a href="https://github.com/poingstudios/godot-admob-android/releases">
+    <img src="https://img.shields.io/github/v/tag/poingstudios/godot-admob-android?label=Version">
   </a>
-  <a href="https://github.com/Poing-Studios/godot-admob-android/actions/workflows/release_android.yml">
-    <img src="https://github.com/Poing-Studios/godot-admob-android/actions/workflows/release_android.yml/badge.svg">
+  <a href="https://github.com/poingstudios/godot-admob-android/actions/workflows/release_android.yml">
+    <img src="https://github.com/poingstudios/godot-admob-android/actions/workflows/release_android.yml/badge.svg">
   </a>
-  <a href="https://github.com/Poing-Studios/godot-admob-android/releases">
-    <img src="https://img.shields.io/github/downloads/Poing-Studios/godot-admob-android/total?style=social">
+  <a href="https://github.com/poingstudios/godot-admob-android/releases">
+    <img src="https://img.shields.io/github/downloads/poingstudios/godot-admob-android/total?style=social">
   </a>
-  <img src="https://img.shields.io/github/stars/Poing-Studios/godot-admob-android?style=social">
-  <img src="https://img.shields.io/github/license/Poing-Studios/godot-admob-android?style=plastic">
+  <img src="https://img.shields.io/github/stars/poingstudios/godot-admob-android?style=social">
+  <img src="https://img.shields.io/github/license/poingstudios/godot-admob-android?style=plastic">
 </p>
 
 <p align="center">
   <a href="#❓-about">About</a> •
   <a href="#🙋‍♂️how-to-use">How to use</a> •
   <a href="#📄documentation">Docs</a> •
-  <a href="https://github.com/Poing-Studios/godot-admob-android/releases">Downloads</a> 
+  <a href="https://github.com/poingstudios/godot-admob-android/releases">Downloads</a> 
 </p>
 
      
@@ -38,7 +38,7 @@
 
 This repository is for a _Godot Engine Plugin_ that allows showing the ads offered by **AdMob** in an **easy** way, without worrying about the building or version, **just download and use**.
 
-The **purpose** of this plugin is to always keep **up to date with Godot**, supporting **ALMOST ALL** versions from v4.1+, and also make the code **compatible** on **Android and [iOS](https://github.com/Poing-Studios/godot-admob-ios)**, so each advertisement will work **identically on both systems**.
+The **purpose** of this plugin is to always keep **up to date with Godot**, supporting **ALMOST ALL** versions from v4.1+, and also make the code **compatible** on **Android and [iOS](https://github.com/poingstudios/godot-admob-ios)**, so each advertisement will work **identically on both systems**.
 
 ### 🔑 Key features
 
@@ -49,18 +49,18 @@ The **purpose** of this plugin is to always keep **up to date with Godot**, supp
 - Targeting Capabilities. 🎯
 - Seamless integration with Mediation partners: **AdColony**, **Meta**, **Vungle**. 💰
 - CI/CD for streamlined development and deployment. 🔄🚀
-- Features a dedicated [Godot Plugin](https://github.com/Poing-Studios/godot-admob-plugin), reducing the need for extensive coding. 🔌
-- There is also an [iOS plugin](https://github.com/Poing-Studios/godot-admob-ios) available, which has the same behavior. 🍎
+- Features a dedicated [Godot Plugin](https://github.com/poingstudios/godot-admob-plugin), reducing the need for extensive coding. 🔌
+- There is also an [iOS plugin](https://github.com/poingstudios/godot-admob-ios) available, which has the same behavior. 🍎
 
 
 ## 🙋‍♂️How to use 
-- We recommend you to use the [AdMob Plugin](https://github.com/Poing-Studios/godot-admob-plugin), you can download direcly from [Godot Assets](https://godotengine.org/asset-library/asset/2063).
-- After download, we recommend you to read the [README.md](https://github.com/Poing-Studios/godot-admob-plugin/blob/master/README.md) of the Plugin to know how to use.
+- We recommend you to use the [AdMob Plugin](https://github.com/poingstudios/godot-admob-plugin), you can download direcly from [Godot Assets](https://godotengine.org/asset-library/asset/2063).
+- After download, we recommend you to read the [README.md](https://github.com/poingstudios/godot-admob-plugin/blob/master/README.md) of the Plugin to know how to use.
 
 ## 📦Installing:
 
 ### 📥Download
-- To get started, download the `poing-godot-admob-android-v{{ your_godot_version }}.zip` file from the [releases tab](https://github.com/Poing-Studios/godot-admob-android/releases). We recommend checking the [supported Godot version](https://github.com/Poing-Studios/godot-admob-versions/blob/master/versions.json) before proceeding. You can also use the [AdMob Plugin](https://github.com/Poing-Studios/godot-admob-plugin) for this step by navigating to `Tools -> AdMob Download Manager -> Android -> LatestVersion`.
+- To get started, download the `poing-godot-admob-android-v{{ your_godot_version }}.zip` file from the [releases tab](https://github.com/poingstudios/godot-admob-android/releases). We recommend checking the [supported Godot version](https://github.com/poingstudios/godot-admob-versions/blob/master/versions.json) before proceeding. You can also use the [AdMob Plugin](https://github.com/poingstudios/godot-admob-plugin) for this step by navigating to `Tools -> AdMob Download Manager -> Android -> LatestVersion`.
 
 ### 🧑‍💻Usage
 - Video tutorial: https://youtu.be/WpVGn7ZasKM.
@@ -79,12 +79,12 @@ The **purpose** of this plugin is to always keep **up to date with Godot**, supp
 
 
 ## 📎Useful links:
-- 🦾 Godot Plugin: https://github.com/Poing-Studios/godot-admob-plugin
-- 🍏 iOS: https://github.com/Poing-Studios/godot-admob-ios
-- ⏳ Plugin for Godot below v4.1: https://github.com/Poing-Studios/godot-admob-android/tree/v2
+- 🦾 Godot Plugin: https://github.com/poingstudios/godot-admob-plugin
+- 🍏 iOS: https://github.com/poingstudios/godot-admob-ios
+- ⏳ Plugin for Godot below v4.1: https://github.com/poingstudios/godot-admob-android/tree/v2
 
 ## 📄Documentation
-For a complete documentation of this Plugin: [check here](https://poing-studios.github.io/godot-admob-plugin/).
+For a complete documentation of this Plugin: [check here](https://poingstudios.github.io/godot-admob-plugin/).
 
 Alternatively, you can check the docs of AdMob itself of [Android](https://developers.google.com/admob/android/quick-start).
 
@@ -101,7 +101,7 @@ Your support helps us continue to improve and maintain this plugin. Thank you fo
 
 
 ## 🆘Getting help
-[![DISCUSSIONS](https://img.shields.io/badge/Discussions-green?style=for-the-badge)](https://github.com/Poing-Studios/godot-admob-android/discussions)
+[![DISCUSSIONS](https://img.shields.io/badge/Discussions-green?style=for-the-badge)](https://github.com/poingstudios/godot-admob-android/discussions)
 [![DISCORD](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge)](https://discord.com/invite/YEPvYjSSMk)
 
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,74 @@ Your support helps us continue to improve and maintain this plugin. Thank you fo
 [![DISCORD](https://img.shields.io/badge/Discord-7289DA?style=for-the-badge)](https://discord.com/invite/YEPvYjSSMk)
 
 
+## Development
+All scripts must be executed within the project root folder
+
+### Downloading
+#### Clear Download & Build Script:
+Unix (Linux & MacOS):
+```shell
+./scripts/unix/clean_build.sh 4.3
+```
+
+Windows:
+```shell
+./scripts/windows/clean_build.ps1 4.3
+```
+
+#### Just Download:
+Unix (Linux & MacOS):
+```shell
+./scripts/unix/download_godot.sh 4.3
+```
+
+Windows:
+```shell
+./scripts/windows/download_godot.ps1 4.3
+```
+
+### Building, Exporting, Zipping
+
+#### Just Build:
+```shell
+./gradlew build
+```
+
+#### Export files:
+```shell
+./gradlew exportFiles -PpluginExportPath=D:\godot-admob-editor\android\plugins
+```
+
+#### Build and exporting plugin files into the desired directory:
+```shell
+./gradlew build ; ./gradlew exportFiles -PpluginExportPath=D:\godot-admob-editor\android\plugins
+```
+
+
+#### Zip:
+(-PgodotVersion is optional)
+```shell
+./gradlew zipPlugins -PgodotVersion=4.1.1 
+```
+
+### Logging
+If you are having some issues with crashing or any expected behavior, you can easily get the log of the plugin with [ADB](https://developer.android.com/tools/adb):
+
+#### Logcat AdMob Plugin & Godot (recommended)
+```shell
+adb logcat -s poing-godot-admob godot
+```
+
+#### Logcat AdMob Plugin
+```shell
+adb logcat -s poing-godot-admob
+```
+
+#### Logcat Godot
+```shell
+adb logcat -s godot
+```
+
 
 ## ⭐ Star History
 If you appreciate our work, don't forget to give us a star on GitHub! ⭐

--- a/src/ads/config/poing-godot-admob-ads.gdap
+++ b/src/ads/config/poing-godot-admob-ads.gdap
@@ -2,7 +2,7 @@
 
 name="AdMob"
 binary_type="local"
-binary="poing-godot-admob-libs/poing-godot-admob-ads-v1.0.0-release.aar"
+binary="poing-godot-admob-libs/poing-godot-admob-ads-v1.0.1-release.aar"
 
 [dependencies]
 

--- a/src/ads/config/poing-godot-admob-ads.gdap
+++ b/src/ads/config/poing-godot-admob-ads.gdap
@@ -7,4 +7,4 @@ binary="poing-godot-admob-libs/poing-godot-admob-ads-v1.0.1-release.aar"
 [dependencies]
 
 local=["poing-godot-admob-libs/poing-godot-admob-core-v1.0.1-release.aar"]
-remote=["com.google.android.gms:play-services-ads:22.4.0"]
+remote=["com.google.android.gms:play-services-ads:23.3.0"]

--- a/src/ads/src/main/java/com/poingstudios/godot/admob/ads/adformats/Banner.kt
+++ b/src/ads/src/main/java/com/poingstudios/godot/admob/ads/adformats/Banner.kt
@@ -144,6 +144,11 @@ class Banner(
             return safeInsetRect
         }
         val window: Window = activity.window?: return safeInsetRect
+
+        if (!isImmersiveModeEnabledLegacy(window)) {
+            return safeInsetRect
+        }
+
         val windowInsets : WindowInsets= window.decorView.rootWindowInsets ?: return safeInsetRect
         val displayCutout : DisplayCutout = windowInsets.displayCutout ?: return safeInsetRect
 
@@ -154,6 +159,15 @@ class Banner(
 
         return safeInsetRect
     }
+
+    @Suppress("DEPRECATION")
+    private fun isImmersiveModeEnabledLegacy(window: Window): Boolean {
+        val uiOptions = window.decorView.systemUiVisibility
+        return (uiOptions and View.SYSTEM_UI_FLAG_FULLSCREEN != 0) &&
+                (uiOptions and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION != 0) &&
+                (uiOptions and View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY != 0)
+    }
+
     private fun getGravity(adPosition: Int?) : Int{
         val gravity = when (adPosition) {
             AdPosition.TOP.ordinal -> Gravity.TOP or Gravity.CENTER_HORIZONTAL
@@ -171,10 +185,11 @@ class Banner(
         return gravity
     }
     private fun getLayoutParams() : FrameLayout.LayoutParams {
+        LogUtils.debug("Safe Area of screen: $safeArea.")
+
         val adParams : FrameLayout.LayoutParams = FrameLayout.LayoutParams(
             FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT
         )
-        LogUtils.debug("Safe Area of screen: $safeArea.")
 
         adParams.gravity = getGravity(adPosition)
         adParams.bottomMargin = safeArea.bottom
@@ -185,7 +200,7 @@ class Banner(
         return adParams
     }
 
-    fun calculateTopMargin(topMargin : Int) : Int{
+    private fun calculateTopMargin(topMargin : Int) : Int{
         var returnValue = topMargin
         when (adPosition) {
             AdPosition.TOP.ordinal, AdPosition.TOP_LEFT.ordinal, AdPosition.TOP_RIGHT.ordinal -> {


### PR DESCRIPTION
Apparently, when Godot is in immersive mode, it continues to calculate the Safe Area unnecessarily, a validation was added to check if Godot is in `immersive_mode`

# Resolution

## Without `immersive_mode` enabled:
![immersive_mode1](https://github.com/user-attachments/assets/505cce2e-f35c-4b7c-9a63-764a5d6ec7c4)

## With `immersive_mode` enabled:
![immersive_mode2](https://github.com/user-attachments/assets/63978a84-7cab-46be-a874-184862312e55)
